### PR TITLE
feat: add required attributes type generic for useBeacon

### DIFF
--- a/src/v3/hooks.ts
+++ b/src/v3/hooks.ts
@@ -29,12 +29,16 @@ const makeEntry = <AllPossibleScopesT>(
  * emit component-render-start, component-render, component-unmount entries
  */
 export const generateUseBeacon =
-  <AllPossibleScopesT extends { [K in keyof AllPossibleScopesT]: ScopeValue }>(
+  <
+    AllPossibleScopesT extends { [K in keyof AllPossibleScopesT]: ScopeValue },
+    RequiredAttributesT = {},
+  >(
     traceManager: TraceManager<AllPossibleScopesT>,
-  ): UseBeacon<AllPossibleScopesT> =>
+  ): UseBeacon<AllPossibleScopesT, RequiredAttributesT> =>
   (
     config: BeaconConfig<
-      GetScopeTFromTraceManager<TraceManager<AllPossibleScopesT>>
+      GetScopeTFromTraceManager<TraceManager<AllPossibleScopesT>>,
+      RequiredAttributesT
     >,
   ) => {
     const renderCountRef = useRef(0)

--- a/src/v3/hooksTypes.ts
+++ b/src/v3/hooksTypes.ts
@@ -4,16 +4,19 @@ import type { ScopeOnASpan } from './types'
 
 export type RenderedOutput = 'null' | 'loading' | 'content' | 'error'
 
-export interface BeaconConfig<AllPossibleScopesT> {
+export type BeaconConfig<AllPossibleScopesT, RequiredAttributesT = {}> = {
   name: string
   scope: ScopeOnASpan<AllPossibleScopesT>
   renderedOutput: RenderedOutput
   isIdle?: boolean
-  attributes?: Attributes
   error?: Error
-}
+} & (keyof RequiredAttributesT extends never
+  ? { attributes?: Attributes }
+  : { attributes: RequiredAttributesT & Attributes })
 
-export type UseBeacon<ScopeT> = (beaconConfig: BeaconConfig<ScopeT>) => void
+export type UseBeacon<ScopeT, RequiredAttributesT> = (
+  beaconConfig: BeaconConfig<ScopeT, RequiredAttributesT>,
+) => void
 
 export type GetScopeTFromTraceManager<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/v3/types.test-d.ts
+++ b/src/v3/types.test-d.ts
@@ -82,7 +82,15 @@ describe('type tests', () => {
       }
     },
   })
+
+  interface RequiredBeaconAttributes {
+    team: string
+  }
   const useBeacon = generateUseBeacon<ExampleAllPossibleScopes>(traceManager)
+  const useBeaconWithRequiredAttributes = generateUseBeacon<
+    ExampleAllPossibleScopes,
+    RequiredBeaconAttributes
+  >(traceManager)
 
   it('works', () => {
     // invalid because in the matcher functions, we cannot compare objects (due to object equality comparison)
@@ -119,6 +127,31 @@ describe('type tests', () => {
       renderedOutput: 'content',
       // @ts-expect-error invalid scope
       scope: { invalid: '123' },
+    })
+
+    // valid beacon with only required attributes
+    useBeaconWithRequiredAttributes({
+      name: 'UserPage',
+      renderedOutput: 'content',
+      scope: { userId: '123' },
+      attributes: { team: 'test' },
+    })
+
+    // valid beacon required attributes and additional attributes
+    useBeaconWithRequiredAttributes({
+      name: 'UserPage',
+      renderedOutput: 'content',
+      scope: { userId: '123' },
+      attributes: { randoKey: 'test', team: 'test' },
+    })
+
+    // invalid beacon missing required attributes
+    useBeaconWithRequiredAttributes({
+      name: 'UserPage',
+      renderedOutput: 'content',
+      scope: { userId: '123' },
+      // @ts-expect-error attributes require a team key
+      attributes: { randoKey: 'test' },
     })
 
     // valid definition


### PR DESCRIPTION
Adds type generic `RequiredAttributesT` for specifying attributes that must be given when using the beacon hook