### PR TITLE
fix: add null guard in `recursivelyRoundValues`

### DIFF
--- a/src/v3/convertToRum.test.ts
+++ b/src/v3/convertToRum.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it } from 'vitest'
-import { convertTraceToRUM } from './convertToRum'
+import { convertTraceToRUM, recursivelyRoundValues } from './convertToRum'
 import { createTraceRecording } from './recordingComputeUtils'
 import type { ActiveTraceInput } from './spanTypes'
 import {
@@ -282,5 +282,204 @@ describe('convertTraceToRUM', () => {
     expect(result.longestSpan.span.duration).toBe(150)
     expect(result.longestSpan.span.type).toBe('component-render')
     expect(result.longestSpan.key).toBe('component-render|long-component')
+  })
+})
+
+describe('recursivelyRoundValues', () => {
+  it('should handle null and undefined values', () => {
+    const input = {
+      nullValue: null,
+      undefinedValue: undefined,
+      number: 1.5,
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.nullValue).toBe(null)
+    expect(result.undefinedValue).toBe(undefined)
+    expect(result.number).toBe(2)
+  })
+
+  it('should return null/undefined when passed as root object', () => {
+    expect(recursivelyRoundValues(null as any)).toBe(null)
+    expect(recursivelyRoundValues(undefined as any)).toBe(undefined)
+  })
+
+  it('should round numeric values using default Math.round', () => {
+    const input = {
+      integer: 42,
+      positiveFloat: 3.141_59,
+      negativeFloat: -2.718_28,
+      zero: 0,
+      largeNumber: 1_234_567.89,
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.integer).toBe(42)
+    expect(result.positiveFloat).toBe(3)
+    expect(result.negativeFloat).toBe(-3)
+    expect(result.zero).toBe(0)
+    expect(result.largeNumber).toBe(1_234_568)
+  })
+
+  it('should use custom round function when provided', () => {
+    const input = {
+      value1: 3.141_59,
+      value2: 2.718_28,
+    }
+
+    const customRound = (x: number) => Math.floor(x * 10) / 10 // Round to 1 decimal
+    const result = recursivelyRoundValues(input, customRound)
+
+    expect(result.value1).toBe(3.1)
+    expect(result.value2).toBe(2.7)
+  })
+
+  it('should preserve non-numeric primitive values', () => {
+    const input = {
+      string: 'hello world',
+      boolean: true,
+      booleanFalse: false,
+      bigint: 123n,
+      symbol: Symbol('test'),
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.string).toBe('hello world')
+    expect(result.boolean).toBe(true)
+    expect(result.booleanFalse).toBe(false)
+    expect(result.bigint).toBe(123n)
+    expect(result.symbol).toBe(input.symbol)
+  })
+
+  it('should handle nested objects recursively', () => {
+    const input = {
+      level1: {
+        number: 1.7,
+        level2: {
+          anotherNumber: 2.3,
+          level3: {
+            deepNumber: 3.9,
+          },
+        },
+      },
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.level1.number).toBe(2)
+    expect(result.level1.level2.anotherNumber).toBe(2)
+    expect(result.level1.level2.level3.deepNumber).toBe(4)
+  })
+
+  it('should handle arrays with mixed types', () => {
+    const input = {
+      mixedArray: [1.5, 'string', 2.7, true, null, undefined, { nested: 3.2 }],
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.mixedArray).toEqual([
+      2, // 1.5 rounded
+      'string', // preserved
+      3, // 2.7 rounded
+      true, // preserved
+      null, // preserved
+      undefined, // preserved
+      { nested: 3 }, // nested object processed
+    ])
+  })
+
+  it('should handle arrays with null/undefined elements', () => {
+    const input = {
+      arrayWithNulls: [1.5, null, 2.7, undefined, 3.9],
+      nestedArrays: [
+        [1.1, null],
+        [undefined, 2.9],
+      ],
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.arrayWithNulls).toEqual([2, null, 3, undefined, 4])
+    expect(result.nestedArrays).toEqual([
+      [1, null],
+      [undefined, 3],
+    ])
+  })
+
+  it('should handle complex nested structures', () => {
+    const input = {
+      data: {
+        metrics: {
+          duration: 123.456,
+          startTime: 789.012,
+          spans: [
+            { offset: 10.7, duration: 20.3 },
+            { offset: 30.9, duration: null },
+            null,
+            { offset: undefined, duration: 40.1 },
+          ],
+        },
+        metadata: {
+          version: '1.0.0',
+          enabled: true,
+          config: {
+            timeout: 5_000.99,
+            retries: 3.14,
+          },
+        },
+      },
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.data.metrics.duration).toBe(123)
+    expect(result.data.metrics.startTime).toBe(789)
+    expect(result.data.metrics.spans[0]).toEqual({ offset: 11, duration: 20 })
+    expect(result.data.metrics.spans[1]).toEqual({ offset: 31, duration: null })
+    expect(result.data.metrics.spans[2]).toBe(null)
+    expect(result.data.metrics.spans[3]).toEqual({
+      offset: undefined,
+      duration: 40,
+    })
+    expect(result.data.metadata.version).toBe('1.0.0')
+    expect(result.data.metadata.enabled).toBe(true)
+    expect(result.data.metadata.config.timeout).toBe(5_001)
+    expect(result.data.metadata.config.retries).toBe(3)
+  })
+
+  it('should handle empty objects and arrays', () => {
+    const input = {
+      emptyObject: {},
+      emptyArray: [],
+      nestedEmpty: {
+        inner: {},
+        innerArray: [],
+      },
+    }
+
+    const result = recursivelyRoundValues(input)
+
+    expect(result.emptyObject).toEqual({})
+    expect(result.emptyArray).toEqual([])
+    expect(result.nestedEmpty.inner).toEqual({})
+    expect(result.nestedEmpty.innerArray).toEqual([])
+  })
+
+  it('should not mutate the original object', () => {
+    const input = {
+      number: 1.5,
+      nested: {
+        array: [2.7, { value: 3.9 }],
+      },
+    }
+
+    const originalInput = JSON.parse(JSON.stringify(input))
+    recursivelyRoundValues(input)
+
+    expect(input).toEqual(originalInput) // Original should be unchanged
   })
 })

--- a/src/v3/convertToRum.ts
+++ b/src/v3/convertToRum.ts
@@ -194,23 +194,30 @@ export function recursivelyRoundValues<T extends object>(
     return obj
   }
 
+  // Handle arrays specially to preserve array structure
+  if (Array.isArray(obj)) {
+    return obj.map((item: unknown) =>
+      typeof item === 'number'
+        ? roundFunc(item)
+        : typeof item === 'string'
+        ? item
+        : typeof item === 'boolean'
+        ? item
+        : item == null
+        ? item
+        : typeof item === 'object'
+        ? recursivelyRoundValues(item as T, roundFunc)
+        : item,
+    ) as T
+  }
+
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(obj as object)) {
     if (typeof value === 'number') {
       result[key] = roundFunc(value)
     } else if (Array.isArray(value)) {
-      result[key] = value.map((item: number | T) =>
-        typeof item === 'number'
-          ? roundFunc(item)
-          : // Keep strings intact - don't process them
-          typeof item === 'string'
-          ? item
-          : // Handle null/undefined in arrays
-          item == null
-          ? item
-          : recursivelyRoundValues(item, roundFunc),
-      )
+      result[key] = recursivelyRoundValues(value, roundFunc)
     } else if (value && typeof value === 'object') {
       result[key] = recursivelyRoundValues(value, roundFunc)
     } else {

--- a/src/v3/convertToRum.ts
+++ b/src/v3/convertToRum.ts
@@ -186,10 +186,14 @@ export function findLongestSpan<
 
 type RoundFunction = (x: number) => number
 
-function recursivelyRoundValues<T extends object>(
+export function recursivelyRoundValues<T extends object>(
   obj: T,
   roundFunc: RoundFunction = (x) => Math.round(x),
 ): T {
+  if (obj == null) {
+    return obj
+  }
+
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(obj as object)) {
@@ -201,6 +205,9 @@ function recursivelyRoundValues<T extends object>(
           ? roundFunc(item)
           : // Keep strings intact - don't process them
           typeof item === 'string'
+          ? item
+          : // Handle null/undefined in arrays
+          item == null
           ? item
           : recursivelyRoundValues(item, roundFunc),
       )


### PR DESCRIPTION
> I noticed elevated error rate in some of our components -> [https://zendesk-us.sentry.io/issues/6451299483/?environment=production&project=6185878&[…]anesGridLayout%2FKnowledge&referrer=issue-stream&sort=date](https://zendesk-us.sentry.io/issues/6451299483/?environment=production&project=6185878&query=context%3AReact%2FTicket%2FPanesGridLayout%2FKnowledge&referrer=issue-stream&sort=date)

> It started around mid-July, approx. the same time when new retrace functionality was introduced - https://github.com/zendesk/zendesk_console/pull/45343

> DD RUM also registers first occurrence on July, 17th: [https://zendesk.datadoghq.com/error-tracking?query=&refresh_mode=sliding&source=all&sp=[…]%7D%5D&from_ts=1757415583463&to_ts=1757501983463&live=true](https://zendesk.datadoghq.com/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22dbd448f2-629c-11f0-bade-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1757415583463&to_ts=1757501983463&live=true)

originally from: https://zendesk.slack.com/archives/C0899KRA9FW/p1757529949186629