### PR TITLE
docs: add AI-ready files (AGENTS.md, ARCHITECTURE.md, SECURITY.md, spokes)

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,9 @@
+---
+description: Core project conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Read and follow all instructions in the root `AGENTS.md` file.
+Read and follow all security requirements in `SECURITY.md`.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,5 +1,3 @@
-# Copilot Instructions
-
 Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
 Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
 See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# retrace
+
+`@zendesk/retrace` is a TypeScript library for defining and capturing Product Operation Traces with computed metrics. It provides a React beacon API (v3 `TraceManager`/`Tracer`/`useBeacon`) and a legacy React hooks API (v1 `generateTimingHooks`/`useTiming`). The primary use case is measuring Time-to-Interactive (TTI), Time-to-Render (TTR), and custom span-based metrics for frontend operations.
+
+## Setup & Commands
+
+```bash
+# Install dependencies
+yarn install --immutable
+
+# Build (both CJS and ESM)
+yarn build
+
+# Run all checks (format + types + lint + code tests)
+yarn test
+
+# Run code tests only (vitest)
+yarn test:code
+# or:
+yarn exec vitest
+
+# Run a single test file
+yarn exec vitest path/to/file.test.ts
+
+# Typecheck only
+yarn test:types
+
+# Lint only
+yarn test:lint
+
+# Format check
+yarn test:format
+
+# Auto-format
+yarn format
+
+# Start Storybook dev server
+yarn storybook
+```
+
+> Node version: see `.node-version`. Package manager: Yarn (see `.yarnrc.yml`).
+
+## Code Conventions
+
+### TypeScript
+- Strict mode is enabled — never use `any`; use `unknown` for external/unverified inputs
+- `verbatimModuleSyntax: true` — always use `import type` or `import { type X }` for type-only imports
+- Prefer `satisfies` over type assertion (`as`) wherever possible
+- Avoid casting; if a type exists, use it
+- `noImplicitOverride`, `noImplicitReturns`, `noUncheckedIndexedAccess` are all enabled
+
+### Style (Prettier)
+- No semicolons
+- Single quotes
+- 2-space indent (no tabs)
+- Trailing commas in multi-line structures
+- Arrow function parens always
+
+### General
+- No default exports (except in config files like `webpack.config.ts`)
+- Copyright header required in all source files (see any existing `.ts`/`.tsx` for the template)
+- `sideEffects: false` — do not introduce side effects at module load time
+
+## Testing
+
+- Framework: Vitest (for `src/v3/` and `src/visualizer/`)
+- V1 legacy tests use Jest patterns (see `jest.config.ts`)
+- Test files: co-located in `src/`, named `*.test.ts` / `*.test.tsx`
+- Type-level tests: `*.test-d.ts` (Vitest type-checking)
+- Run only v3/visualizer tests: `yarn exec vitest` (matches `src/v3/**/*.test.ts` and `src/visualizer/**/*.test.ts`)
+- Test utilities live in `src/v3/testUtility/`
+
+## Do
+
+- Use `import type` / `import { type X }` for every type-only import
+- Use `satisfies` to validate shapes rather than casting with `as`
+- Keep `src/main.ts` as the single public API surface — all exports must go through it
+- Write co-located tests alongside source files
+- Use the ASCII timeline serializer (`src/v3/testUtility/asciiTimelineSerializer.ts`) for trace snapshot tests
+- Use RxJS `Subject` for event emission inside `TraceManager` — the pattern is established
+- Mark new spans via `traceManager.processSpan(...)` or the beacon hooks — do not bypass `TraceManager`
+- Prefer functional/procedural design; keep data and behavior separate
+
+## Don't
+
+- Don't use `any` — use `unknown` and narrow with type guards
+- Don't use bare type assertions (`as Foo`) when `satisfies` or narrowing is possible
+- Don't omit `import type` for type-only imports (breaks `verbatimModuleSyntax`)
+- Don't add side effects at module level — the package is marked `"sideEffects": false`
+- Don't export from `src/v3/` or `src/v1/` directly in consumer code — use the root `src/main.ts` exports
+- Don't use tabs (ESLint `no-tabs` rule enforced)
+- Don't hardcode span type strings inline — use the established constants and types in `src/v3/constants.ts` and `src/v3/spanTypes.ts`
+
+## Architecture
+
+See `ARCHITECTURE.md` for the system diagram, component map, v1 vs v3 API comparison, and design decisions.
+
+## Security
+
+See `SECURITY.md` for mandatory security requirements, prohibited patterns, and escalation triggers.
+
+## Safety & Permissions
+
+Allowed without approval:
+- Read/list files
+- Run single-file tests (`yarn exec vitest path/to/file.test.ts`)
+- Run type checks and linters
+- Run Storybook locally
+
+Ask before:
+- Installing or removing packages
+- Running the full build or full test suite
+- Modifying CI/CD workflows (`.github/workflows/`)
+- Publishing or releasing
+
+## PR & Commit Guidelines
+
+- PR title format: `type: short description` (e.g., `feat: add draft trace support`, `fix: null guard in recursivelyRoundValues`, `chore: update dependencies`)
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- Uses semantic-release — commit messages drive versioning; follow [Conventional Commits](https://www.conventionalcommits.org/)
+- `feat:` → minor bump, `fix:` → patch bump, `BREAKING CHANGE:` in footer → major bump
+- Keep PRs focused; prefer small, reviewable changes
+
+## References
+
+- Architecture: `ARCHITECTURE.md`
+- Security: `SECURITY.md`
+- v3 model overview: `src/v3/docs/model-overview.md`
+- v1 usage guide: `src/v1/README.md`
+- v3 trace design notes: `src/v3/README.md`
+- Storybook examples: `src/stories/`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# retrace — Architecture
+
+## System Overview
+
+`@zendesk/retrace` is a published TypeScript library (dual CJS + ESM) that instruments frontend applications with Product Operation Traces. It captures browser performance entries, React component render spans, and custom spans into a structured `TraceRecording`, which can be forwarded to observability services (e.g., Datadog RUM) or downloaded for local debugging. The library ships two major APIs: a v3 `TraceManager`/`Tracer` system and a legacy v1 `generateTimingHooks` React hooks API.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    App["Consumer App<br/>(React)"]
+    Beacon["useBeacon hook<br/>src/v3/hooks.ts"]
+    TM["TraceManager<br/>src/v3/TraceManager.ts"]
+    Tracer["Tracer<br/>src/v3/Tracer.ts"]
+    Trace["Trace<br/>src/v3/Trace.ts"]
+    RxJS["RxJS Subjects<br/>(internal event bus)"]
+    Recording["TraceRecording<br/>src/v3/traceRecordingTypes.ts"]
+    RUM["Observability / RUM<br/>(Datadog, etc.)"]
+    PerfObs["PerformanceObserver<br/>src/v3/observePerformanceWithTraceManager.ts"]
+    Viz["Visualizer<br/>src/visualizer/"]
+
+    App -->|"creates tracer"| Tracer
+    App -->|"mounts"| Beacon
+    Tracer -->|"startTrace / draftTrace"| TM
+    Beacon -->|"processSpan"| TM
+    PerfObs -->|"processSpan"| TM
+    TM -->|"manages lifecycle"| Trace
+    TM -->|"events"| RxJS
+    Trace -->|"on complete/interrupt"| Recording
+    Recording -->|"reportFn callback"| RUM
+    Recording -->|"JSON file"| Viz
+```
+
+## Directory Map
+
+| Path | Responsibility | Notes |
+|------|---------------|-------|
+| `src/main.ts` | Public API surface — all library exports | Single entry point |
+| `src/v3/TraceManager.ts` | Central singleton; receives spans, manages active `Trace` | One trace active at a time |
+| `src/v3/Tracer.ts` | Per-definition handle; creates `Trace` instances via `TraceManager` | Created per operation definition |
+| `src/v3/Trace.ts` | Lifecycle of a single operation trace | States: draft → active → complete/interrupted |
+| `src/v3/hooks.ts` | `generateUseBeacon` — React hook that emits render spans | Used in consumer components |
+| `src/v3/types.ts` | Core type definitions: `TraceDefinition`, `RelationSchemas`, etc. | Generic over `RelationSchemasT` |
+| `src/v3/spanTypes.ts` | Span type unions and input types | Component render, perf entry, error |
+| `src/v3/matchSpan.ts` | Span matching DSL (`match.*` helpers) | Used in trace definitions |
+| `src/v3/traceRecordingTypes.ts` | Output shape: `TraceRecording`, `RecordedSpan` | Serializable JSON |
+| `src/v3/convertToRum.ts` | Converts `TraceRecording` to RUM-compatible format | Datadog RUM integration helper |
+| `src/v3/firstCPUIdle.ts` | CPU idle / TTI computation algorithm | Based on Long Tasks / Long Animation Frames |
+| `src/v3/observePerformanceWithTraceManager.ts` | Wires `PerformanceObserver` to `TraceManager` | Auto-ingests browser perf entries |
+| `src/v3/ConsoleTraceLogger.ts` | Debug logger that prints traces to console | Dev/testing utility |
+| `src/v3/TraceManagerDebugger.tsx` | React component for in-app trace visualization | Dev overlay |
+| `src/v3/testUtility/` | Test helpers: mock factory, ASCII timeline serializer | Test-only |
+| `src/v3/docs/` | Design docs: model overview, TTI, FCI, crumbs | Reference docs |
+| `src/v1/` | Legacy `generateTimingHooks` / `useTiming` API | Stable; new work goes in v3 |
+| `src/visualizer/` | Standalone React app for visualizing trace JSON files | Storybook-hosted |
+| `src/stories/` | Storybook stories and mock app components | Dev examples |
+| `src/ErrorBoundary.tsx` | `ReactMeasureErrorBoundary` + `useOnErrorBoundaryDidCatch` | Integrates errors into traces |
+| `.storybook/` | Storybook configuration | Dev only |
+| `scripts/` | Release utilities (TOTP-based npm publish) | CI/CD only |
+
+## Key Design Decisions
+
+### Single Active Trace
+Only one `Product Operation Trace` can be active at a time in a `TraceManager` instance. A new trace starting automatically interrupts the previous one. This simplifies span attribution but means care is needed around concurrent operations.
+
+### Generic over `RelationSchemasT`
+The entire v3 API is generic over a `RelationSchemasBase` type parameter that describes the relations a trace can carry (e.g., `{ ticket: { ticketId: Number } }`). This provides full type-safety for span matching and relation lookups with zero runtime overhead.
+
+### RxJS for Internal Events
+`TraceManager` uses RxJS `Subject`s as an internal event bus (`trace-start`, `state-transition`, `required-span-seen`, `add-span-to-recording`, `definition-modified`). This decouples event production from consumption and enables the debugger/logger to subscribe without coupling.
+
+### Dual Build: CJS + ESM
+The library is built as both CommonJS (`cjs/`) and ESM (`esm/`) via TypeScript compiler + Webpack. The ESM build uses a custom Webpack plugin (`PostProcessChunkWebpackPlugin`) to rename `__webpack_require__` to avoid conflicts in host app bundlers.
+
+### v1 vs v3 APIs
+- **v1** (`generateTimingHooks`, `useTiming`): legacy React hooks API, TTI/TTR focused, simpler interface. Still supported for existing consumers.
+- **v3** (`TraceManager`, `Tracer`, `useBeacon`): full Product Operation Trace model with relations, computed spans, RUM export, parent/child traces, and a visualizer.
+
+## Data Flow
+
+1. Consumer calls `tracer.start({ relatedTo, variant })` on a user event
+2. `TraceManager` creates a `Trace` instance and sets it as active
+3. React components with `useBeacon` emit `component-render-start` / `component-render` spans on each render
+4. `PerformanceObserver` (via `observePerformanceWithTraceManager`) feeds browser perf entries as spans
+5. Each span is matched against the active trace's `requiredSpans` and `interruptionCriteria`
+6. When all required spans are seen (debounce settles), the trace transitions to `complete`
+7. A `TraceRecording` is generated and passed to the consumer's `onTraceEnd` / `reportFn` callback
+8. Consumer forwards the recording to Datadog RUM or other observability backend
+
+## External Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `rxjs` | Internal event bus in `TraceManager` (only runtime dependency) |
+| `react` / `react-dom` | Peer dependency — beacon hooks require React |
+| Webpack | ESM bundle build (dev dependency) |
+| Vitest | Test runner for v3 and visualizer |
+| Storybook | Interactive dev/demo environment |
+| semantic-release | Automated versioning and NPM publish |
+| `@visx/*` | Visualizer charting components (dev only) |
+| `@zendeskgarden/*` | Visualizer UI components (dev only) |
+
+## Cross-Cutting Concerns
+
+### Configuration
+No runtime config object — all behavior is configured through `TraceDefinition` objects passed to `Tracer` constructor, and `TraceManagerConfig` passed to `TraceManager` constructor.
+
+### Observability
+The library _is_ the observability tool. It emits `TraceRecording` JSON which consumers route to their preferred backend. The `ConsoleTraceLogger` and `TraceManagerDebugger` are available for local development.
+
+### Error Handling
+- `ReactMeasureErrorBoundary` catches React render errors and injects them as error spans into active traces
+- Span processing errors are non-fatal; they are reported via the optional `reportErrorFn` in `TraceManagerConfig`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Copilot Instructions
+# Claude Code Configuration
 
 Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
 Read and follow all instructions in `SECURITY.md` — mandatory security requirements.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,143 @@
-# Security Policy
+# Security
 
-## Supported Versions
+## For AI Agents
+
+This section defines mandatory security principles and restrictions for all AI coding assistants operating in this repository.
+
+**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
+
+---
+
+### Core Security Mandate
+
+Security is a first-class requirement. Every code suggestion must be evaluated against these guidelines. If a request would result in insecure code:
+
+1. **Stop** and flag the security concern
+2. **Explain** why it's problematic
+3. **Propose** a secure alternative
+
+AI-generated code requires human review before merging.
+
+---
+
+### Absolute Prohibitions
+
+AI agents must **NEVER** do the following:
+
+#### Secrets & Credentials
+- Hardcode secrets, credentials, API keys, tokens, or passwords in source code
+- Store secrets in version control (`.env` files with real values, config with real credentials)
+- Log, print, or expose secret values
+- Expose credentials in URLs, logs, or error messages
+
+#### Security Controls
+- Disable or weaken security controls (`verify=False`, `ALLOW_ALL` CORS, disabled auth)
+- Bypass authentication or authorization checks
+- Disable certificate validation
+- Weaken password policies or MFA requirements
+
+#### Dangerous Code Patterns
+- Use `eval()` or `exec()` with user-supplied input
+- Implement custom cryptography
+- Use deprecated algorithms (MD5, SHA-1, DES, RC4, ECB mode)
+
+#### Data Exposure
+- Log sensitive data (PII, credentials, tokens, customer data)
+- Expose stack traces or internal paths to end users
+- Transmit sensitive data over unencrypted channels
+
+---
+
+### Required Security Patterns
+
+#### Secret Management
+
+```typescript
+// Correct: environment variable
+const apiKey = process.env.MY_SERVICE_API_KEY
+
+// NEVER: hardcoded secret
+const apiKey = 'sk-abc123XYZ'
+```
+
+#### Dependency Security
+- This project uses Dependabot and Renovate for automated dependency updates (see `.github/dependabot.yml` and `.github/renovate.json`)
+- Do not pin dependencies to versions with known CVEs
+- Do not downgrade a dependency past a security fix without explicit justification
+
+#### Bundle Safety
+- The library is `"sideEffects": false` — do not introduce module-level side effects that could execute code unexpectedly in host apps
+- Do not introduce dependencies that perform network calls at import time
+
+---
+
+### Security Requirements by Domain
+
+#### Data Protection
+- This library processes timing/performance data — none of it should include PII
+- Do not capture user-identifiable information in span attributes or trace metadata without explicit consumer opt-in
+- `TraceRecording` JSON output is consumer-controlled — document clearly what data is captured when adding new span attributes
+
+#### Cryptography
+
+| Use Case | Approved | Forbidden |
+|----------|----------|-----------|
+| Integrity hashing | SHA-256, SHA-3 | MD5, SHA-1 |
+| Symmetric encryption | AES-256-GCM | DES, 3DES, AES-ECB |
+| TLS | TLS 1.2+ | SSLv2/3, TLS 1.0/1.1 |
+
+#### Communication Security (release pipeline)
+- NPM publish uses TOTP-based authentication (see `scripts/npm-release-with-totp.mjs`)
+- `NPM_TOKEN` and `NPM_TOTP_DEVICE` secrets are managed in the GitHub `npm-publish` environment — never log or expose them
+- Do not modify the publish script to bypass TOTP verification
+
+#### CodeQL
+- This repo runs CodeQL scanning on every push and PR (see `.github/workflows/codeql.yaml`)
+- Do not suppress CodeQL findings without security team review
+
+---
+
+### When to Stop and Escalate
+
+Stop, explain the concern, and recommend involving Security if a task requires:
+
+- Bypassing or weakening security controls
+- Exposing customer data or PII
+- Circumventing the npm publish authentication
+- Disabling CodeQL scanning or other security checks
+- Using deprecated protocols or algorithms
+- Adding dependencies with known unpatched CVEs
+
+---
+
+### Security Testing
+
+When generating features, include:
+
+- Negative test cases for invalid/unexpected inputs
+- Boundary condition tests and error path coverage
+- Checks that error boundaries do not leak sensitive error details to end users
+
+---
+
+### References
+
+- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
+- [Cryptography Standards](https://techmenu.zende.sk/standards/cryptography-standards/)
+- [Unified JWT Standard](https://techmenu.zende.sk/standards/unified-jwt/)
+
+---
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by e-mailing: security@zendesk.com
+
+### Supported Versions
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 2.x.x   | :white_check_mark: |
 
-## Reporting a Vulnerability
+---
 
-Please report security vulnerabilities by e-mailing: security@zendesk.com
+**Questions?** Reach out to the Security team or file a ticket via the Security Engagement process.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` — vendor-neutral hub with project overview, exact commands, TypeScript conventions, testing patterns, do/don't lists, and PR guidelines (migrates all content from the previous `copilot-instructions.md`)
- Add `ARCHITECTURE.md` — system diagram, directory map, v1 vs v3 API comparison, data flow, key design decisions, and external dependencies
- Expand `SECURITY.md` — adds AI agent security constraints (absolute prohibitions, required patterns, escalation triggers, CodeQL/TOTP notes) while preserving the existing vulnerability reporting section
- Add thin spoke files: `CLAUDE.md`, `.github/copilot-instructions.md` (updated), `.cursor/rules/00-core.mdc`, `.windsurfrules` — all reference the hub files

## Test plan

- [ ] Review `AGENTS.md` for accuracy of commands, conventions, and do/don't items
- [ ] Review `ARCHITECTURE.md` diagram and component map against actual source structure
- [ ] Review `SECURITY.md` for completeness of AI agent constraints and accuracy of vulnerability reporting section
- [ ] Verify spoke files (`CLAUDE.md`, `copilot-instructions.md`, `.cursor/rules/00-core.mdc`, `.windsurfrules`) reference hubs correctly and contain no duplicated content
- [ ] Confirm CI passes (no source code was modified)

---
Requested by @nimishadoongarwal via [zendesk/ai-repo#385](https://github.com/zendesk/ai-repo/issues/385)